### PR TITLE
Feature/keep current tab

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import GoogleDrive from '../GoogleDrive.js'
 import LocalStore from '../LocalStore.js'
-import {ITEM_TYPE_RECENT, ITEM_TYPE_FAVORITE, ITEM_TYPE_SEARCH, SAVE_KEY_SEARCH_TEXT} from '../constants.js'
+import {ITEM_TYPE_RECENT, ITEM_TYPE_FAVORITE, ITEM_TYPE_SEARCH, SAVE_KEY_SEARCH_TEXT, SAVE_KEY_LAST_ITEM_TYPE} from '../constants.js'
 
 export const TYPE_NONE                  = 'NONE'
 export const TYPE_SHOW_ITEMS            = 'SHOW_ITEMS'
@@ -107,6 +107,7 @@ export const resetAuthToken = () => {
 
 export const requestItems = (itemType) => {
   clearLastRequest()
+  LocalStore.save(SAVE_KEY_LAST_ITEM_TYPE, itemType)
   return (dispatch) => {
     dispatch(loadLocalItems(itemType))
     if (itemType === ITEM_TYPE_SEARCH) {

--- a/src/components/ItemList.js
+++ b/src/components/ItemList.js
@@ -2,14 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import moment from 'moment'
 import GoogleDrive from '../GoogleDrive.js'
+import LocalStore from '../LocalStore.js'
 import { requestItems, requestNextPageItems } from '../actions'
-import {ITEM_TYPE_RECENT, ITEM_TYPE_FAVORITE, ITEM_TYPE_SEARCH} from '../constants.js'
+import {ITEM_TYPE_RECENT, ITEM_TYPE_FAVORITE, ITEM_TYPE_SEARCH, SAVE_KEY_LAST_ITEM_TYPE} from '../constants.js'
 import styles from './ItemList.css'
 
 const define_initialize_callback = (dispatch) => {
   window.initialize_items_list = () => {
     GoogleDrive.auth(true, () => {
-      dispatch(requestItems(ITEM_TYPE_FAVORITE))
+      LocalStore.load(SAVE_KEY_LAST_ITEM_TYPE, (results) => {
+        dispatch(requestItems(results[SAVE_KEY_LAST_ITEM_TYPE] || ITEM_TYPE_FAVORITE))
+      })
     })
   }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,4 +2,4 @@ export const ITEM_TYPE_RECENT   = 'recent'
 export const ITEM_TYPE_FAVORITE = 'favorite'
 export const ITEM_TYPE_SEARCH   = 'search'
 export const SAVE_KEY_SEARCH_TEXT = 'searchText'
-
+export const SAVE_KEY_LAST_ITEM_TYPE = 'lastItemType'


### PR DESCRIPTION
# Keep current tab

- Modify to save last opened tab & restore it when launching the extension.
- Related to #5. (I didn't implement the default tab setting because I wanna keep simplicity.)